### PR TITLE
HTTPs GitHub Source URL instead of SSH

### DIFF
--- a/NSDate-Extensions-iOS7.podspec
+++ b/NSDate-Extensions-iOS7.podspec
@@ -28,7 +28,7 @@ LICENSE
   s.summary  = 'Practical real-world dates. Updated for iOS7 and up.'
   s.homepage = 'http://ericasadun.com'
   s.author   = { 'Erica Sadun' => 'erica@ericasadun.com' }
-  s.source   = { :git => 'git@github.com:HiTask/NSDate-Extensions.git', :tag => '1.0.1' }
+  s.source   = { :git => 'https://github.com/HiTask/NSDate-Extensions.git', :tag => '1.0.1' }
   s.platform = :ios
   s.source_files = 'NSDate+Utilities.{h,m}'
   s.framework = 'Foundation'


### PR DESCRIPTION
Because of the SSH Source URL the repo link on the Pod page https://cocoapods.org/pods/NSDate-Extensions-iOS7 is broken.
It also seems to cause an "Permission denied (publickey)" error for users without a SSH public key.
See also: https://groups.google.com/forum/#!topic/cocoapods/fvki9qZYkFU
