### PR TITLE
Fix a warning I'm seeing in Xcode 7.1

### DIFF
--- a/NSDate+Utilities.m
+++ b/NSDate+Utilities.m
@@ -176,7 +176,7 @@ static const unsigned componentFlags = (NSCalendarUnitYear| NSCalendarUnitMonth 
 	if (components1.weekOfYear != components2.weekOfYear) return NO;
 	
 	// Must have a time interval under 1 week. Thanks @aclark
-	return (abs([self timeIntervalSinceDate:aDate]) < D_WEEK);
+	return (fabs([self timeIntervalSinceDate:aDate]) < D_WEEK);
 }
 
 - (BOOL) isThisWeek


### PR DESCRIPTION
NSDate+Utilities.m:179:10: Using integer absolute value function 'abs' when argument is of floating point type.

timeIntervalSinceDate returns an NSTimeInterval, which is defined as:

```
typedef double NSTimeInterval;
```

Using fabs is preferred instead of abs for doubles.
